### PR TITLE
TY-2250 disable some lints in generated files [2]

### DIFF
--- a/async-bindgen-derive/src/lib.rs
+++ b/async-bindgen-derive/src/lib.rs
@@ -75,7 +75,13 @@ fn parse_gen_api(attrs: TokenStream2, item: TokenStream2) -> Result<AsyncBindgen
 
     let mut file_tokens = quote! {
         #![doc(hidden)]
-        #![allow(clippy::unused_unit, clippy::semicolon_if_nothing_returned, clippy::used_underscore_binding, unreachable_pub)]
+        #![allow(
+            clippy::unused_unit,
+            clippy::semicolon_if_nothing_returned,
+            clippy::used_underscore_binding,
+            clippy::module_name_repetitions,
+            unreachable_pub,
+        )]
     };
     file_tokens.extend(api.header_code().clone());
     file_tokens.extend(generate_type(&api));
@@ -167,7 +173,14 @@ mod tests {
         "#,
             r##"
             #![doc(hidden)]
-            #![allow(clippy::unused_unit, clippy::semicolon_if_nothing_returned, clippy::used_underscore_binding, unreachable_pub)]
+            #![allow(
+                clippy::unused_unit,
+                clippy::semicolon_if_nothing_returned,
+                clippy::used_underscore_binding,
+                clippy::module_name_repetitions,
+                unreachable_pub,
+            )]
+
             pub struct BarFoot;
             #[doc = r" Initializes the dart api."]
             #[doc = r""]
@@ -244,8 +257,14 @@ mod tests {
         "#,
             r##"
             #![doc(hidden)]
-            #![allow(clippy::unused_unit, clippy::semicolon_if_nothing_returned, clippy::used_underscore_binding, unreachable_pub)]
-            pub struct BarFoot;
+            #![allow(
+                clippy::unused_unit,
+                clippy::semicolon_if_nothing_returned,
+                clippy::used_underscore_binding,
+                clippy::module_name_repetitions,
+                unreachable_pub,
+            )]
+                        pub struct BarFoot;
             #[doc = r" Initializes the dart api."]
             #[doc = r""]
             #[doc = r" It's safe to be called multiple times and from multiple threads."]
@@ -327,8 +346,14 @@ mod tests {
         "#,
             r##"
             #![doc(hidden)]
-            #![allow(clippy::unused_unit, clippy::semicolon_if_nothing_returned, clippy::used_underscore_binding, unreachable_pub)]
-            pub struct BarFoot;
+            #![allow(
+                clippy::unused_unit,
+                clippy::semicolon_if_nothing_returned,
+                clippy::used_underscore_binding,
+                clippy::module_name_repetitions,
+                unreachable_pub,
+            )]
+                        pub struct BarFoot;
             #[doc = r" Initializes the dart api."]
             #[doc = r""]
             #[doc = r" It's safe to be called multiple times and from multiple threads."]

--- a/async-bindgen-derive/src/lib.rs
+++ b/async-bindgen-derive/src/lib.rs
@@ -75,7 +75,7 @@ fn parse_gen_api(attrs: TokenStream2, item: TokenStream2) -> Result<AsyncBindgen
 
     let mut file_tokens = quote! {
         #![doc(hidden)]
-        #![allow(clippy::unused_unit, clippy::semicolon_if_nothing_returned, clippy::used_underscore_binding)]
+        #![allow(clippy::unused_unit, clippy::semicolon_if_nothing_returned, clippy::used_underscore_binding, unreachable_pub)]
     };
     file_tokens.extend(api.header_code().clone());
     file_tokens.extend(generate_type(&api));
@@ -167,7 +167,7 @@ mod tests {
         "#,
             r##"
             #![doc(hidden)]
-            #![allow(clippy::unused_unit, clippy::semicolon_if_nothing_returned, clippy::used_underscore_binding)]
+            #![allow(clippy::unused_unit, clippy::semicolon_if_nothing_returned, clippy::used_underscore_binding, unreachable_pub)]
             pub struct BarFoot;
             #[doc = r" Initializes the dart api."]
             #[doc = r""]
@@ -244,7 +244,7 @@ mod tests {
         "#,
             r##"
             #![doc(hidden)]
-            #![allow(clippy::unused_unit, clippy::semicolon_if_nothing_returned, clippy::used_underscore_binding)]
+            #![allow(clippy::unused_unit, clippy::semicolon_if_nothing_returned, clippy::used_underscore_binding, unreachable_pub)]
             pub struct BarFoot;
             #[doc = r" Initializes the dart api."]
             #[doc = r""]
@@ -327,7 +327,7 @@ mod tests {
         "#,
             r##"
             #![doc(hidden)]
-            #![allow(clippy::unused_unit, clippy::semicolon_if_nothing_returned, clippy::used_underscore_binding)]
+            #![allow(clippy::unused_unit, clippy::semicolon_if_nothing_returned, clippy::used_underscore_binding, unreachable_pub)]
             pub struct BarFoot;
             #[doc = r" Initializes the dart api."]
             #[doc = r""]

--- a/integration-tests-bindings/src/lib.rs
+++ b/integration-tests-bindings/src/lib.rs
@@ -24,11 +24,7 @@
     unsafe_op_in_unsafe_fn
 )]
 #![warn(missing_docs, unreachable_pub)]
-#![allow(
-    clippy::must_use_candidate,
-    clippy::items_after_statements,
-    clippy::module_name_repetitions
-)]
+#![allow(clippy::must_use_candidate, clippy::items_after_statements)]
 
 mod async_bindings;
 

--- a/integration-tests-bindings/src/lib.rs
+++ b/integration-tests-bindings/src/lib.rs
@@ -30,7 +30,7 @@
     clippy::module_name_repetitions
 )]
 
-pub mod async_bindings;
+mod async_bindings;
 
 #[async_bindgen::api(
     // Imports here must be absolute.


### PR DESCRIPTION
No mangle functions are implicit pub, so there is no point in not making them rust-pub. But they might not be exported to the normal rust library API, in which case this lint would trigger, so the lint got disabled for the generated code.

`clippy::module_name_repetitions` flags the repetition in the `no_mangle` extern C functions where it's needed to prevent name collisions.