### PR TITLE
Switches from async-std to tokio.

### DIFF
--- a/async-bindgen/Cargo.toml
+++ b/async-bindgen/Cargo.toml
@@ -9,5 +9,5 @@ async-bindgen-derive = { path = "../async-bindgen-derive" }
 once_cell = "1.9.0"
 static_assertions = "1.1.0"
 thiserror = "1.0.30"
-tokio = { version = "1.15.0", features = ["rt", "rt-multi-thread"] }
+tokio = { version = "1.15.0", features = ["rt", "rt-multi-thread"], default-features = false }
 xayn-dart-api-dl = "0.3.0"

--- a/async-bindgen/Cargo.toml
+++ b/async-bindgen/Cargo.toml
@@ -6,7 +6,8 @@ license = "Apache-2.0"
 
 [dependencies]
 async-bindgen-derive = { path = "../async-bindgen-derive" }
-async-std = "1.10.0"
+once_cell = "1.9.0"
 static_assertions = "1.1.0"
 thiserror = "1.0.30"
+tokio = { version = "1.15.0", features = ["rt", "rt-multi-thread"] }
 xayn-dart-api-dl = "0.3.0"

--- a/async-bindgen/src/async_runtime.rs
+++ b/async-bindgen/src/async_runtime.rs
@@ -1,0 +1,51 @@
+//! Provides ways to handle the async runtime used by async-bindgen.
+//!
+use std::future::Future;
+use tokio::runtime::{Handle, Runtime};
+
+use once_cell::sync::OnceCell;
+
+static RUNTIME: OnceCell<Runtime> = OnceCell::new();
+
+/// Runs a closure inside of an runtime.
+///
+/// If we are already are inside of an runtime that runtime
+/// is used.
+///
+/// If we are not in a runtime a new runtime is created.
+///
+/// For now there is no way to interact with that runtime besides
+/// this method, similar there is for now no way to set an external
+/// created runtime.
+///
+/// # Panics
+///
+/// Panics if a runtime needs to be created and that fails.
+///
+/// Normally creating a runtime doesn't fail.
+///
+/// Through `tokio` doesn't document when runtime creation
+/// can fail.
+pub fn with_runtime<R>(run: impl FnOnce() -> R) -> R {
+    if Handle::try_current().is_ok() {
+        run()
+    } else {
+        let rt = RUNTIME.get_or_init(|| Runtime::new().expect("creating tokio runtime failed"));
+        let handle = rt.handle();
+        let guard = handle.enter();
+        let r = run();
+        drop(guard);
+        r
+    }
+}
+
+/// Spawns a future on a runtime.
+///
+/// # Panics
+///
+/// Panics if a runtime needs to be created and that fails.
+///
+/// Normally creating a runtime doesn't fail.
+pub fn spawn(future: impl Future<Output = ()> + Send + 'static) {
+    with_runtime(|| tokio::spawn(future));
+}

--- a/async-bindgen/src/async_runtime.rs
+++ b/async-bindgen/src/async_runtime.rs
@@ -1,5 +1,18 @@
+// Copyright 2022 Xayn AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Provides ways to handle the async runtime used by async-bindgen.
-//!
 use std::future::Future;
 use tokio::runtime::{Handle, Runtime};
 

--- a/async-bindgen/src/async_runtime.rs
+++ b/async-bindgen/src/async_runtime.rs
@@ -20,15 +20,15 @@ use once_cell::sync::OnceCell;
 
 static RUNTIME: OnceCell<Runtime> = OnceCell::new();
 
-/// Runs a closure inside of an runtime.
+/// Runs a closure inside of a runtime.
 ///
-/// If we are already are inside of an runtime that runtime
+/// If we already are inside of a runtime, that runtime
 /// is used.
 ///
 /// If we are not in a runtime a new runtime is created.
 ///
 /// For now there is no way to interact with that runtime besides
-/// this method, similar there is for now no way to set an external
+/// this method, similar there is for now no way to set an externally
 /// created runtime.
 ///
 /// # Panics
@@ -37,7 +37,7 @@ static RUNTIME: OnceCell<Runtime> = OnceCell::new();
 ///
 /// Normally creating a runtime doesn't fail.
 ///
-/// Through `tokio` doesn't document when runtime creation
+/// Though `tokio` doesn't document when runtime creation
 /// can fail.
 pub fn with_runtime<R>(run: impl FnOnce() -> R) -> R {
     if Handle::try_current().is_ok() {

--- a/async-bindgen/src/dart.rs
+++ b/async-bindgen/src/dart.rs
@@ -27,6 +27,8 @@ use thiserror::Error;
 
 pub use xayn_dart_api_dl::{initialize_dart_api_dl, ports::DartPortId};
 
+use crate::async_runtime::spawn;
+
 /// An id indicating which future will be completed.
 pub type CompleterId = i64;
 /// A magic way to pass back results (currently this is a pointer turned into an int).
@@ -147,18 +149,6 @@ impl Drop for PreparedCompleter {
 #[derive(Debug, Error)]
 #[error("Setting up the completer failed.")]
 pub struct CompleterSetupFailed;
-
-/// Spawns the future.
-///
-// In the future this should allow different implementations (potentially
-// with a cfg, for now only async-std as it's easier to use).
-fn spawn(future: impl Future<Output = ()> + Send + 'static) {
-    // noticeable more complex with tokio as:
-    // - We need a handle to the runtime, but are not in the runtime
-    //  - So we need to store the handle in some global slot and
-    //    have an init runtime function.
-    async_std::task::spawn(future);
-}
 
 /// Undos what `encode_box_pointer` does.
 ///

--- a/async-bindgen/src/lib.rs
+++ b/async-bindgen/src/lib.rs
@@ -32,4 +32,5 @@
 
 pub use async_bindgen_derive::api;
 
+pub mod async_runtime;
 pub mod dart;

--- a/integration_tests/pubspec.lock
+++ b/integration_tests/pubspec.lock
@@ -35,7 +35,7 @@ packages:
       path: "../async_bindgen_dart_utils"
       relative: true
     source: path
-    version: "1.0.0"
+    version: "0.1.0"
   boolean_selector:
     dependency: transitive
     description:


### PR DESCRIPTION
Uses `tokio` instead of `async-std`.

While this will normally create it's own runtime when called from C/Dart there should be no problem to use it with `#[tokio::test]` or `#[tokio::main]`.

Through if (outside of testing) we have to run something with an async-runtime from  (potential) outside of a runtime we should prefer using `async_bindgen::async_runtime::spawn` (or `with_runtime`).