### PR TITLE
TY-2896 update rust toolchain to 1.61.0

### DIFF
--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -17,7 +17,7 @@ permissions:
   contents: read
 
 env:
-  RUST_NIGHTLY: nightly-2021-09-09
+  RUST_NIGHTLY: nightly-2022-05-19
   RUST_WORKSPACE: ${{ github.workspace }}/
   RUSTFLAGS: "-D warnings"
   DISABLE_AUTO_DART_FFIGEN: 1

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.55.0"
+channel = "1.61.0"
 components = [ "clippy" ]
 profile = "minimal"


### PR DESCRIPTION
**References**

- [TY-2896]
- https://github.com/xaynetwork/xayn_discovery_engine/pull/427
- https://github.com/xaynetwork/xayn_dart_api_dl/pull/11

**Summary**

- update toolchain versions
